### PR TITLE
feat: add lumiere (funnel tracking)

### DIFF
--- a/src/components/home/Landing.js
+++ b/src/components/home/Landing.js
@@ -1,10 +1,12 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import styled from 'styled-components'
 import { useStaticQuery, graphql } from 'gatsby'
 import { MDXRenderer } from 'gatsby-plugin-mdx'
 
 import Section from 'src/components/layout/Section'
 import SubscribeForm from './landing/SubscribeForm'
+import { sendEvent, setUserProperties } from 'src/utils/lumiere'
+import queryString from 'query-string'
 
 const StyledSection = styled(Section)`
   h1 {
@@ -50,6 +52,11 @@ const StyledSection = styled(Section)`
   }
 `
 export default function Landing(props) {
+  useEffect(() => {
+    setUserProperties({ qs: queryString.parse(window.location.search) })
+    sendEvent(['landing', 'open'])
+  }, [props])
+  
   const data = useStaticQuery(
     graphql`
       query {

--- a/src/components/profile/formWrapper/Form.js
+++ b/src/components/profile/formWrapper/Form.js
@@ -1,7 +1,8 @@
-import React, { useState, useLayoutEffect, useContext, useRef } from 'react'
+import React, { useState, useLayoutEffect, useContext, useRef, useEffect } from 'react'
 import styled from 'styled-components'
 
 import ProfileContext from 'src/utils/ProfileContext'
+import { sendEvent } from 'src/utils/lumiere'
 import Title from './form/Title'
 import Address from './form/Address'
 import Step from './form/Step'
@@ -30,6 +31,12 @@ export default function Form(props) {
   useLayoutEffect(() => {
     setMinHeight(ref.current.clientHeight)
   }, [complete])
+
+  useEffect(() => {
+    if (form[current]) {
+      sendEvent(['inscription', 'open_step', { step: form[current].name }])
+    }
+  }, [current])
 
   return (
     <Wrapper minHeight={minHeight}>

--- a/src/components/profile/formWrapper/Form.js
+++ b/src/components/profile/formWrapper/Form.js
@@ -36,7 +36,7 @@ export default function Form(props) {
     if (form[current]) {
       sendEvent(['inscription', 'open_step', { step: form[current].name }])
     }
-  }, [current])
+  }, [current, form])
 
   return (
     <Wrapper minHeight={minHeight}>

--- a/src/components/profile/formWrapper/form/Conclusion.js
+++ b/src/components/profile/formWrapper/form/Conclusion.js
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import styled from 'styled-components'
 
+import { sendEvent } from 'src/utils/lumiere'
 import Button from 'src/components/base/Button'
 import Step from './Step'
 
@@ -22,6 +23,9 @@ const StyledButton = styled(Button)`
   margin-bottom: 1.5rem;
 `
 export default function Conclusion(props) {
+  useEffect(() => {
+    sendEvent(['inscription', 'open_step', { step: 'connaissance_produit' }])
+  }, [])
   return (
     <Wrapper>
       <Title

--- a/src/html.js
+++ b/src/html.js
@@ -31,7 +31,7 @@ export default function HTML(props) {
               c.crossorigin = true;
               c.src = "https://lumiere.cleverapps.io/lib.js?a=" + i + "&n=" + E + "&e=" + r + "&d=" + e + "&b=" + s + "&t=" + Date.now();
               h.appendChild(c);
-            })(window, document, "lumiere", isProduction ? "app_OhCe2M7kNRcXu5Fuueff2" : "app_OhCe2M7kNRcXu5Fuueff2", "app", isProduction, !isProduction, !isProduction);`,
+            })(window, document, "lumiere", isProduction ? "app_z_8CdZLKpTtXQR6RcvgVC" : "none", "default", isProduction, !isProduction, !isProduction);`,
           }}
         />
         {props.headComponents}

--- a/src/html.js
+++ b/src/html.js
@@ -16,6 +16,24 @@ export default function HTML(props) {
           rel='search'
           href='opensearch.xml'
         />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+            var isProduction = window.location.href.indexOf("recosante.beta.gouv.fr") !== -1;
+            (function (l, u, m, i, E, r, e, s) {
+              l[m] = function () {
+                (l[m].q = l[m].q || []).push(arguments);
+              };
+              var c = u.createElement("script"),
+                h = u.getElementsByTagName("head")[0];
+              c.type = "text/javascript";
+              c.async = true;
+              c.crossorigin = true;
+              c.src = "https://lumiere.cleverapps.io/lib.js?a=" + i + "&n=" + E + "&e=" + r + "&d=" + e + "&b=" + s + "&t=" + Date.now();
+              h.appendChild(c);
+            })(window, document, "lumiere", isProduction ? "app_OhCe2M7kNRcXu5Fuueff2" : "app_OhCe2M7kNRcXu5Fuueff2", "app", isProduction, !isProduction, !isProduction);`,
+          }}
+        />
         {props.headComponents}
       </head>
       <body {...props.bodyAttributes}>

--- a/src/utils/lumiere.js
+++ b/src/utils/lumiere.js
@@ -1,0 +1,14 @@
+export const LUM_SEND_EVENT = 'sendEvent'
+export const LUM_SET_USER_PROPERTIES = 'setUserProperties'
+
+export default function lumiere(action, props) {
+  window.lumiere(action, ...props)
+}
+
+export function sendEvent(props) {
+  lumiere(LUM_SEND_EVENT, props)
+}
+
+export function setUserProperties(props) {
+  lumiere(LUM_SET_USER_PROPERTIES, [props])
+}


### PR DESCRIPTION
Discussion ouverte sur Slack. Le but est d'ajouter un tracker pour analyser les comportements des utilisateurs (funnel d'inscription). _D'un point de vue implémentation ça ressemble à matomo en mode privacy (envoi d'events seulement, cookie http only limité au domaine, etc.)._