### PR TITLE
Ajout évolution des inscriptions

### DIFF
--- a/src/components/stats/ActiveUsers.js
+++ b/src/components/stats/ActiveUsers.js
@@ -17,11 +17,11 @@ const Wrapper = styled.div`
   width: 100%;
   height: 25rem;
 `
-export default function Subscriptions(props) {
+export default function ActiveUsers(props) {
   const { themes, theme } = useContext(StyleContext)
-  const data = Object.keys(props.subscriptions).map((key) => ({
+  const data = Object.keys(props.activeUsers).map((key) => ({
     date: key,
-    inscriptions: props.subscriptions[key],
+    inscriptions: props.activeUsers[key],
   }))
 
   const [width, setWidth] = useState(null)
@@ -32,7 +32,7 @@ export default function Subscriptions(props) {
   return (
     <Section xlarge>
       <Section.Title center>
-        <strong>{props.totalSubscriptions}</strong> abonné·e·s
+        <strong>{props.totalActifs}</strong> abonné·e·s
       </Section.Title>
       <Wrapper>
         <ResponsiveContainer>

--- a/src/components/stats/CurrentMonth.js
+++ b/src/components/stats/CurrentMonth.js
@@ -1,0 +1,58 @@
+import React, { useState, useEffect, useContext } from 'react'
+import styled from 'styled-components'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts'
+
+import StyleContext from 'src/utils/StyleContext'
+import Section from 'src/components/layout/Section'
+
+const Wrapper = styled.div`
+  width: 100%;
+  height: 25rem;
+`
+
+export default function CurrentMonth(props) {
+  const { themes, theme } = useContext(StyleContext)
+
+  const weeks = new Set([...Object.keys(props.inscriptions), ...Object.keys(props.desinscriptions)])
+  const data = Array.from(weeks).map((key) => ({
+    semaine: `Semaine ${key}`,
+    inscriptions: props.inscriptions[key],
+    desinscriptions: -props.desinscriptions[key]
+  })).filter(d => !isNaN(d.inscriptions) && !isNaN(d.desinscriptions))
+  console.log(themes[theme].colors)
+
+  const [width, setWidth] = useState(null)
+  useEffect(() => {
+    setTimeout(() => setWidth(window.innerWidth), 100)
+  }, [])
+
+  return (
+      <Section xlarge>
+          <Section.Title center>Évolution des inscriptions</Section.Title>
+          <Wrapper>
+              <ResponsiveContainer>
+                  <BarChart data={data}>
+                      <XAxis
+                        dataKey="semaine"
+                        tick={{ fontSize: 12 }}
+                        interval={width < 1200 ? 'preserveStartEnd' : 0}
+                        />
+                        <YAxis/>
+                        <Tooltip />
+                        <Legend />
+                        <Bar dataKey='inscriptions' fill={themes[theme].colors.main} />
+                        <Bar dataKey='desinscriptions' fill={themes[theme].colors.error} />
+                  </BarChart>
+              </ResponsiveContainer>
+          </Wrapper>
+      </Section>
+  )
+}

--- a/src/components/stats/Profile.js
+++ b/src/components/stats/Profile.js
@@ -22,12 +22,12 @@ export default function Profile(props) {
   return (
     <StyledSection xlarge>
       <Text center>
-        <strong>{Math.round((props.nb_allergies / props.total) * 100)}%</strong>
+        <strong>{Math.round((props.total_allergies / props.total) * 100)}%</strong>
         <br /> des utilisateurs se déclarent allergiques aux pollens.
       </Text>
       <Text center>
         <strong>
-          {Math.round((props.nb_pathologie_respiratoire / props.total) * 100)}%
+          {Math.round((props.total_pathologie_respiratoire / props.total) * 100)}%
         </strong>
         <br /> des utilisateurs déclarent avoir une pathologie respiratoire.
       </Text>

--- a/src/pages/stats.js
+++ b/src/pages/stats.js
@@ -2,7 +2,8 @@ import React, { useState, useEffect } from 'react'
 
 import api from 'src/utils/api'
 import Web from 'src/components/layout/Web'
-import Subscriptions from 'src/components/stats/Subscriptions'
+import ActiveUsers from 'src/components/stats/ActiveUsers'
+import CurrentMonth from 'src/components/stats/CurrentMonth'
 import Profile from 'src/components/stats/Profile'
 import Satisfaction from 'src/components/stats/Satisfaction'
 import MailOpening from 'src/components/stats/MailOpening'
@@ -20,16 +21,20 @@ export default function Stats(props) {
     <Web title={'Statistiques'}>
       {data && (
         <>
-          {data.subscriptions && (
-            <Subscriptions
-              subscriptions={JSON.parse(data.subscriptions)}
-              totalSubscriptions={data.nb_inscriptions}
+          {data.total_actifs && (
+            <ActiveUsers
+              activeUsers={JSON.parse(data.active_users)}
+              totalActifs={data.total_actifs}
             />
           )}
+          <CurrentMonth
+            inscriptions={data.inscriptions}
+            desinscriptions={data.desinscriptions}
+          />
           <Profile
-            nb_allergies={data.nb_allergies}
-            nb_pathologie_respiratoire={data.nb_pathologie_respiratoire}
-            total={data.nb_inscriptions}
+            total_allergies={data.total_allergies}
+            total_pathologie_respiratoire={data.total_pathologie_respiratoire}
+            total={data.total_actifs}
           />
           {data.decouverte && (
             <Satisfaction satisfaction={JSON.parse(data.decouverte)} />


### PR DESCRIPTION
Ce commit ajoute une nouvelle section dans les stats pour suivre
l’évolution semaine par semaine des inscriptions et des désinscriptions.

À merger en même temps que cette [PR](https://github.com/betagouv/recosante-api/pull/194)	.
Les noms de certaines variables ont changé pour être plus de cohérence
entre elles.

Zoom sur la section ajoutée
![image](https://user-images.githubusercontent.com/2757318/113186387-e2cfa080-9257-11eb-9deb-192ea30b650d.png)
