### PR TITLE
Affiche le message d’erreur de l’API en cas d’erreur lors de l’inscription

### DIFF
--- a/src/components/home/landing/SubscribeForm.js
+++ b/src/components/home/landing/SubscribeForm.js
@@ -96,7 +96,21 @@ export default function SubscribeForm() {
             setFetching(false)
             navigate(`/inscription/?user=${res.uid}`)
           })
-          .catch((error) => setError(error.message))
+          .catch((error) => {
+            if ("mail" in error.json) {
+              setError(error.json.mail[0])
+            } else {
+              setError(error.message)
+            }
+            window._paq &&
+              window._paq.push([
+                'trackEvent',
+                'Subscription',
+                'Landing',
+                'Api error',
+              ])
+            setFetching(false)
+          })
       }}
     >
       <MailInput

--- a/src/components/home/landing/SubscribeForm.js
+++ b/src/components/home/landing/SubscribeForm.js
@@ -89,7 +89,7 @@ export default function SubscribeForm() {
 
         setFetching(true)
         api
-          .post(`https://ecosante.beta.gouv.fr/inscription/premiere-etape`, {
+          .post(`/inscription/premiere-etape`, {
             mail: email,
           })
           .then((res) => {

--- a/src/components/providers/ProfileProvider.js
+++ b/src/components/providers/ProfileProvider.js
@@ -44,7 +44,7 @@ export default function ProfileProvider(props) {
   const fetchProfile = useCallback(
     (body) =>
       api
-        .fetch(`https://ecosante.beta.gouv.fr/inscription/${uid}`, body)
+        .fetch(`/inscription/${uid}`, body)
         .then((res) =>
           setProfile({
             ...res,
@@ -87,7 +87,7 @@ export default function ProfileProvider(props) {
   useEffect(() => {
     complete &&
       api
-        .fetch(`https://ecosante.beta.gouv.fr/inscription/${uid}/_confirm`)
+        .fetch(`/inscription/${uid}/_confirm`)
         .catch(setError)
   }, [uid, complete])
 

--- a/src/components/referral/Form.js
+++ b/src/components/referral/Form.js
@@ -31,7 +31,7 @@ export default function InscriptionPatients(props) {
         } else {
           const patientsArray = patients.replaceAll(', ', ',').split(',')
           api
-            .fetch(`https://ecosante.beta.gouv.fr/inscription-patients`, {
+            .fetch(`/inscription-patients`, {
               nom_medecin: user,
               mails: patientsArray,
             })

--- a/src/pages/stats.js
+++ b/src/pages/stats.js
@@ -12,7 +12,7 @@ export default function Stats(props) {
   const [data, setData] = useState(null)
   useEffect(() => {
     api
-      .fetch(`https://ecosante.beta.gouv.fr/stats/`)
+      .fetch(`/stats/`)
       .then((res) => setData(res))
       .catch((error) => console.log(error))
   }, [])

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -5,8 +5,11 @@ export default {
     }
     return response
   },
+  makeEndpointURL(endpoint) {
+    return (process.env.GATSBY_API_BASE_URL || 'https://ecosante.beta.gouv.fr') + endpoint
+  },
   get(endpoint) {
-    return fetch(endpoint, {
+    return fetch(this.makeEndpointURL(endpoint), {
       headers: {
         Accept: 'application/json',
       },
@@ -15,7 +18,7 @@ export default {
       .then((res) => res.json())
   },
   post(endpoint, body) {
-    return fetch(endpoint, {
+    return fetch(this.makeEndpointURL(endpoint), {
       method: 'POST',
       headers: {
         Accept: 'application/json',

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,7 +1,12 @@
 export default {
-  handleErrors(response) {
+  async handleErrors(response) {
     if (!response.ok) {
-      throw Error(response.statusText)
+      let error = new Error(response.statusText)
+      if (response.headers.get('Content-Type') === "application/json") {
+        let json = await response.json()
+        error.json = json
+      }
+      throw error
     }
     return response
   },


### PR DESCRIPTION
Pour l’instant ce n’est fait que pour la première étape.

J’en ai profité pour rendre configurable l’URL de base de l’API.

Ce message est affiché en cas d’erreur 
![image](https://user-images.githubusercontent.com/2757318/114697617-6d1b0880-9d1e-11eb-9226-2c8801032a4b.png)

fix https://github.com/betagouv/recosante-api/issues/204
