### PR TITLE
Recuperation application server key

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,3 +1,7 @@
+require("dotenv").config({
+  path: `.env.${process.env.NODE_ENV}`,
+})
+
 module.exports = {
   siteMetadata: {
     title: `Recosanté - Connaître son environnement. Agir pour sa santé `,

--- a/src/components/Indicators.js
+++ b/src/components/Indicators.js
@@ -20,10 +20,7 @@ export default function Indicators(props) {
 
   const { user, mutateUser } = useLocalUser()
 
-  const notifications = useNotificationsPrompt(
-    '/sw.js',
-    'BEl62iUYgUivxIkv69yViEuiBIa-Ib9-SkvMeAtA3LFgDzkrxZJjSgSnfckjBJuBkr3qBUYIHBQFLXYp5Nksh8U'
-  )
+  const notifications = useNotificationsPrompt('/sw.js')
 
   return (
     <Wrapper>

--- a/src/components/Notifications.js
+++ b/src/components/Notifications.js
@@ -14,10 +14,7 @@ export default function Notifications() {
   const { data } = useUser()
   const mutation = useUserMutation()
   const [success, setSuccess] = useState(false)
-  const notifications = useNotificationsPrompt(
-    '/sw.js',
-    'BEl62iUYgUivxIkv69yViEuiBIa-Ib9-SkvMeAtA3LFgDzkrxZJjSgSnfckjBJuBkr3qBUYIHBQFLXYp5Nksh8U'
-  )
+  const notifications = useNotificationsPrompt('/sw.js')
 
   return user ? (
     <Section first small>

--- a/src/hooks/useUser.js
+++ b/src/hooks/useUser.js
@@ -4,6 +4,8 @@ import axios from 'axios'
 import { useQueryParam } from 'use-query-params'
 
 import UserContext from 'utils/UserContext'
+import { make_api_url } from '../utils/api'
+
 
 export function useUser() {
   const [uid] = useQueryParam('user')
@@ -11,7 +13,7 @@ export function useUser() {
     ['user', uid],
     () =>
       axios
-        .get(`https://staging.api.recosante.beta.gouv.fr/users/${uid}`)
+        .get(make_api_url(`users/${uid}`))
         .then((res) => res.data),
     {
       enabled: uid ? true : false,
@@ -26,7 +28,7 @@ export function useUserMutation() {
   return useMutation(
     (user) =>
       axios.post(
-        `https://staging.api.recosante.beta.gouv.fr/users/${uid || ''}`,
+        make_api_url(`users/${uid || ''}`),
         { ...user, commune: user.commune && { code: user.commune.code } },
         {
           headers: { Accept: ' application/json' },

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -2,6 +2,10 @@ import { useQuery, useMutation } from 'react-query'
 import axios from 'axios'
 import { useQueryParam } from 'use-query-params'
 
+export function make_api_url(endpoint) {
+  return `${process.env.GATSBY_API_BASE_URL||'https://api.recosante.beta.gouv.fr'}/${endpoint}`
+}
+
 export function useIndicators(code) {
   return useQuery(
     ['indicators', code],


### PR DESCRIPTION
Permet aussi de passer l’URL de base de l’API en variable d’environnement par exemple en ayant un fichier `.env.development` à la racine du répertoire ayant comme contenu : 
```
GATSBY_API_BASE_URL=http://localhost:5000
```

À ce stade, je reçois lors d’une inscription les informations qui me permettent pour un utilisateur de créer avec succès une notification.
Elle n’apparaît cependant pas chez l’utilisateur, je pense qu’il reste à implémenter ça https://developer.mozilla.org/fr/docs/Web/API/PushEvent