### PR TITLE
Reset du padding du bouton more

### DIFF
--- a/src/components/misc/card/Mobile.js
+++ b/src/components/misc/card/Mobile.js
@@ -19,7 +19,7 @@ const ButtonMore = styled.button`
   background-color: ${(props) => props.theme.colors.background};
   border: 0.125rem solid ${(props) => props.theme.colors.main};
   border-radius: 0.5rem;
-
+  padding: 0;
   svg {
     width: 1rem;
     height: 1rem;


### PR DESCRIPTION
Fix #168

Cause : padding par défaut des boutons sur Safari Mobile

<img width="314" alt="button-padding-mobile-safari" src="https://user-images.githubusercontent.com/23194091/148926606-2ad490ee-6dd3-45cf-a225-87149d619d3a.png">

