### PR TITLE
Revue du plan de taggage Matomo

### DIFF
--- a/src/components/providers/ModalProvider.js
+++ b/src/components/providers/ModalProvider.js
@@ -29,6 +29,7 @@ export default function ModalProvider(props) {
                 'Souhaitez-vous vraiment abandonner votre inscription ?'
               )
             ) {
+              window?._paq?.push(['trackEvent', 'Subscription', 'Close'])
               setSubscription(value)
             }
           }

--- a/src/components/search/SearchBar.js
+++ b/src/components/search/SearchBar.js
@@ -86,6 +86,7 @@ export default function SearchBar(props) {
           isFetching={isFetching}
           setCurrent={setCurrent}
           handleSuggestionClick={(place) => {
+            window?._paq?.push(['trackEvent', 'Search', 'PlaceInput', place.nom])
             setSearch(place.nom)
             props.handlePlaceSelection(place)
             setFocus(false)

--- a/src/components/search/Suggestions.js
+++ b/src/components/search/Suggestions.js
@@ -24,28 +24,60 @@ const StyledButton = styled(Button)`
 export default function Suggestions() {
   return (
     <Wrapper>
-      <StyledButton hollow to='/place/75056/paris/'>
+      <StyledButton hollow to='/place/75056/paris/'
+        onClick={() => {
+          window?._paq?.push(['trackEvent', 'Search', 'PlaceSuggestion', 'Paris'])
+        }}
+      >
         Paris
       </StyledButton>
-      <StyledButton hollow to='/place/13055/marseille/'>
+      <StyledButton hollow to='/place/13055/marseille/'
+        onClick={() => {
+          window?._paq?.push(['trackEvent', 'Search', 'PlaceSuggestion', 'Marseille'])
+        }}
+      >
         Marseille
       </StyledButton>
-      <StyledButton hollow to='/place/69123/lyon/'>
+      <StyledButton hollow to='/place/69123/lyon/'
+        onClick={() => {
+          window?._paq?.push(['trackEvent', 'Search', 'PlaceSuggestion', 'Lyon'])
+        }}
+      >
         Lyon
       </StyledButton>
-      <StyledButton hollow to='/place/31555/toulouse/'>
+      <StyledButton hollow to='/place/31555/toulouse/'
+        onClick={() => {
+          window?._paq?.push(['trackEvent', 'Search', 'PlaceSuggestion', 'Toulouse'])
+        }}
+      >
         Toulouse
       </StyledButton>
-      <StyledButton hollow to='/place/06088/nice/'>
+      <StyledButton hollow to='/place/06088/nice/'
+        onClick={() => {
+          window?._paq?.push(['trackEvent', 'Search', 'PlaceSuggestion', 'Nice'])
+        }}
+      >
         Nice
       </StyledButton>
-      <StyledButton hollow to='/place/44109/nantes/'>
+      <StyledButton hollow to='/place/44109/nantes/'
+        onClick={() => {
+          window?._paq?.push(['trackEvent', 'Search', 'PlaceSuggestion', 'Nantes'])
+        }}
+      >
         Nantes
       </StyledButton>
-      <StyledButton hollow to='/place/34172/montpellier/'>
+      <StyledButton hollow to='/place/34172/montpellier/'
+        onClick={() => {
+          window?._paq?.push(['trackEvent', 'Search', 'PlaceSuggestion', 'Montpellier'])
+        }}
+      >
         Montpellier
       </StyledButton>
-      <StyledButton hollow to='/place/67482/strasbourg/'>
+      <StyledButton hollow to='/place/67482/strasbourg/'
+        onClick={() => {
+          window?._paq?.push(['trackEvent', 'Search', 'PlaceSuggestion', 'Strasbourg'])
+        }}
+      >
         Strasbourg
       </StyledButton>
     </Wrapper>

--- a/src/components/search/searchBar/textInput/Geoloc.js
+++ b/src/components/search/searchBar/textInput/Geoloc.js
@@ -64,6 +64,7 @@ export default function Submit(props) {
     if (data && !done) {
       setDone(true)
       if (data[0]) {
+        window?._paq?.push(['trackEvent', 'Search', 'Geoloc', data[0].nom])
         handlePlaceSelection(data[0])
       } else {
         setError(true)

--- a/src/components/subscription/Navigation.js
+++ b/src/components/subscription/Navigation.js
@@ -72,11 +72,12 @@ export default function Navigation(props) {
     <Wrapper prevButtonVisible={prevButtonVisible}>
       {prevButtonVisible && (
         <PreviousButton
-          onClick={() =>
+          onClick={() => {
+            window?._paq?.push(['trackEvent', 'Subscription', 'Prev', props.steps[props.currentStep].name])
             props.currentStep > 0
               ? props.setCurrentStep(props.currentStep - 1)
               : props.gotoDeepLastStep()
-          }
+          }}
           hollow
           noExpand
         >
@@ -92,7 +93,10 @@ export default function Navigation(props) {
             !user[props.steps[props.currentStep].name]?.length &&
             props.steps[props.currentStep].mandatory
           }
-          onClick={() => props.setCurrentStep(props.currentStep + 1)}
+          onClick={() => {
+            window?._paq?.push(['trackEvent', 'Subscription', 'Next', props.steps[props.currentStep].name])
+            props.setCurrentStep(props.currentStep + 1)
+          }}
           fetching={props.prompting}
           noExpand
         >

--- a/src/components/subscription/identity/NavigationIdentity.js
+++ b/src/components/subscription/identity/NavigationIdentity.js
@@ -47,7 +47,11 @@ const NextButton = styled(Button)`
 export default function NavigationIdentity(props) {
   return (
     <Wrapper>
-      <NextButton type='submit' fetching={props.fetching} noExpand>
+      <NextButton type='submit' fetching={props.fetching} noExpand
+        onClick={() => {
+          window?._paq?.push(['trackEvent', 'Subscription', 'Validate'])
+        }}
+      >
         Valider{' '}
         <svg width='15' height='24' viewBox='0 0 15 24'>
           <path d='M14.6416 12.0001C14.6416 12.4302 14.4774 12.8603 14.1496 13.1882L3.83004 23.5077C3.17359 24.1641 2.10926 24.1641 1.45308 23.5077C0.796891 22.8515 0.796891 21.7874 1.45308 21.1309L10.5844 12.0001L1.4534 2.86922C0.79721 2.21277 0.79721 1.14876 1.4534 0.49263C2.10958 -0.164141 3.17391 -0.164141 3.83036 0.49263L14.1499 10.8119C14.4778 11.14 14.6416 11.5701 14.6416 12.0001Z' />
@@ -55,7 +59,10 @@ export default function NavigationIdentity(props) {
       </NextButton>
       <PreviousButton
         type='button'
-        onClick={props.setPreviousStep}
+        onClick={() => {
+          window?._paq?.push(['trackEvent', 'Subscription', 'Prev', 'identity'])
+          props.setPreviousStep()
+        }}
         hollow
         noExpand
       >

--- a/src/components/subscription/identity/Success.js
+++ b/src/components/subscription/identity/Success.js
@@ -75,7 +75,9 @@ export default function Success(props) {
     setNeedConfirmation(false)
   }, [setNeedConfirmation])
   const newsletter = props?.data?.data?.recommandations[0] === 'oui'
-
+  if (props.data) {
+    window?._paq?.push(['trackEvent', 'Subscription', 'Success'])
+  }
   return (
     <Wrapper visible={props.data}>
       <Title>
@@ -96,6 +98,9 @@ export default function Success(props) {
           to={`/profil?user=${props?.data?.data?.uid}&token=${props?.data?.data?.authentication_token}${
             iframe ? '&iframe=1' : ''
           }`}
+          onClick={() => {
+            window?._paq?.push(['trackEvent', 'Subscription', 'Profil', 'Informations'])
+          }}
           hollow
         >
           Modifier mes informations
@@ -110,6 +115,9 @@ export default function Success(props) {
             to={`/profil?user=${props?.data?.data?.uid}&token=${props?.data?.data?.authentication_token}${
               iframe ? '&iframe=1' : ''
             }`}
+            onClick={() => {
+              window?._paq?.push(['trackEvent', 'Subscription', 'Profil', 'Recommandations'])
+            }}
           >
             M’abonner aux recommandations
           </StyledButton>

--- a/src/components/subscription/question/Disclaimer.js
+++ b/src/components/subscription/question/Disclaimer.js
@@ -43,7 +43,12 @@ export default function Disclaimer(props) {
     <Wrapper>
       <Title>Vous recevrez un email par semaine.</Title>
       <Text>Vous pourrez vous désabonner à tout moment</Text>
-      <Link onClick={() => props.setModal('newsletter')}>
+      <Link
+        onClick={() => {
+          window?._paq?.push(['trackEvent', 'Subscription', 'InfolettreDisclaimer'])
+          props.setModal('newsletter')
+        }}
+      >
         Voir un exemple d'email que je recevrai
       </Link>
     </Wrapper>

--- a/src/components/subscription/question/Option.js
+++ b/src/components/subscription/question/Option.js
@@ -119,10 +119,11 @@ export default function Option(props) {
       </Button>
       {props.option.detail && (
         <Detail
-          onClick={() =>
+          onClick={() => {
+            window?._paq?.push(['trackEvent', 'Subscription', 'NotificationDetail'])
             props.option.detail.modal &&
             props.setModal(props.option.detail.modal)
-          }
+          }}
           modal={props.option.detail.modal}
         >
           {props.option.detail.label}


### PR DESCRIPTION
12 tags ont été ajoutés notamment pour suivre la recherche de commune et le parcours de souscription :
- Search ➡️ PlaceSuggestion / <PLACE>
- Search ➡️ Geoloc / <PLACE>
- Search ➡️ PlaceInput / <PLACE>
- Subscription ➡️ Next / <STEP>
- Subscription ➡️ Prev / <STEP>
- Subscription ➡️ NotificationDetail
- Subscription ➡️ InfolettreDisclaimer
- Subscription ➡️ Validate
- Subscription ➡️ Success
- Subscription ➡️ Close
- Subscription ➡️ Profil / Informations
- Subscription ➡️ Profil / Recommandations

Le plan de taggage complet est documenté sur cette [feuille de calcul](https://docs.google.com/spreadsheets/d/18sxd8ud9PVoqAUh3SiQniYUMNgumVkZN39_7OaVXzAY/edit?usp=sharing).
