### PR TITLE
Mise à jour du plugin Matomo

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gatsby-plugin-gatsby-cloud": "^4.0.0",
     "gatsby-plugin-image": "^2.0.0",
     "gatsby-plugin-manifest": "^4.0.0",
-    "gatsby-plugin-matomo": "^0.10.0",
+    "gatsby-plugin-matomo": "^0.13.0",
     "gatsby-plugin-mdx": "^3.0.0",
     "gatsby-plugin-offline": "^5.0.0",
     "gatsby-plugin-polyfill-io": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6051,10 +6051,10 @@ gatsby-plugin-manifest@^4.0.0:
     semver "^7.3.5"
     sharp "^0.29.1"
 
-gatsby-plugin-matomo@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.npmjs.org/gatsby-plugin-matomo/-/gatsby-plugin-matomo-0.10.0.tgz"
-  integrity sha512-ghtWLfs4tkanB6B6rMZPcH8y5F99GTV0hpupxDWkxk1RrCRyGEDhHJ6QpmDp62Tkkss1EfoXXPia8E3IV+qP9g==
+gatsby-plugin-matomo@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-matomo/-/gatsby-plugin-matomo-0.13.0.tgz#abf1bd561f3ca35c57b8bbbd5d8e87579ba17886"
+  integrity sha512-zwmxcwOoDi3hjNQoUJehoC5XwQKgR+bArAAvArGJWHlJqv7G688tlmKgbIGqEUj3aFSdyWAzAM7QhEt68buMNw==
 
 gatsby-plugin-mdx@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
`warn Plugin gatsby-plugin-matomo is not compatible with your gatsby version 4.15.1 - It requires gatsby@^2.0.0 || ^3.0.0` au start