### PR TITLE
Suppression de la saisie libre lorsque infolettre non utile

### DIFF
--- a/src/components/Opinion.js
+++ b/src/components/Opinion.js
@@ -1,31 +1,13 @@
-import React, { useState } from 'react'
+import React from 'react'
 import styled from 'styled-components'
-import { useLocation } from '@reach/router'
 
-import { useAvis, useAvisMutation } from 'utils/api'
 import Section from 'components/base/Section'
-import TextArea from 'components/base/TextArea'
-import Button from 'components/base/Button'
-import Alert from 'components/base/Alert'
-
 const Text = styled.p`
   ${(props) => props.theme.mq.small} {
     font-size: 1rem;
   }
 `
-const Form = styled.form``
-const ButtonWrapper = styled.div`
-  display: flex;
-  justify-content: flex-end;
-`
 export default function Opinion() {
-  const location = useLocation()
-
-  const { data } = useAvis(location)
-  const mutation = useAvisMutation(location)
-
-  const [message, setMessage] = useState('')
-
   return (
     <Section small first>
       <Section.Title>
@@ -37,31 +19,6 @@ export default function Opinion() {
         Merci pour votre contribution ! C'est grâce à vos retours que nous
         construisons un service utile !
       </Text>
-      {data && !data.appliquee && (
-        <Form
-          onSubmit={(e) => {
-            e.preventDefault()
-            mutation.mutate({ avis: message })
-          }}
-        >
-          <TextArea
-            value={message}
-            onChange={({ value }) => setMessage(value)}
-            label='Aidez-nous à comprendre pourquoi vous n’allez pas appliquer cette recommandation en écrivant quelques mots'
-          />
-          <ButtonWrapper>
-            <Button>Envoyer</Button>
-          </ButtonWrapper>
-          {mutation.isSuccess ||
-            (mutation.isError && (
-              <Alert error={mutation.isError}>
-                {mutation.isSuccess
-                  ? 'Merci de nous avoir envoyé votre avis'
-                  : 'Une erreur est survenue'}
-              </Alert>
-            ))}
-        </Form>
-      )}
     </Section>
   )
 }

--- a/src/components/Opinion.js
+++ b/src/components/Opinion.js
@@ -1,13 +1,19 @@
 import React from 'react'
 import styled from 'styled-components'
+import { useLocation } from '@reach/router'
 
+import { useAvis } from 'utils/api'
 import Section from 'components/base/Section'
+
 const Text = styled.p`
   ${(props) => props.theme.mq.small} {
     font-size: 1rem;
   }
 `
 export default function Opinion() {
+  const location = useLocation()
+  useAvis(location)
+
   return (
     <Section small first>
       <Section.Title>


### PR DESCRIPTION
Avant :
<img width="745" alt="avis-utile-non-avant" src="https://user-images.githubusercontent.com/23194091/200777033-58ca7883-85b1-4488-924a-a774c5a1ca6f.png">

Après :
<img width="659" alt="avis-utile-non-apres" src="https://user-images.githubusercontent.com/23194091/200777050-41503007-29e7-4ad1-85b3-e7521e0281f4.png">

La saisie de messages libres n'était plus fonctionnelle depuis mai 2021. Il y a eu 56 avis rattachés à des emails mais ils avaient plutôt l'air de concerner des recommandations sur la base des indicateurs